### PR TITLE
ci: upgrade rustfmt-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: rustfmt
-        uses: mbrobbel/rustfmt-check@2d0978f
+        uses: mbrobbel/rustfmt-check@b8caf241958773f7f6b0fba68879316da6be821d
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/daily-lints.yml
+++ b/.github/workflows/daily-lints.yml
@@ -20,7 +20,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: rustfmt
-        uses: mbrobbel/rustfmt-check@2d0978f
+        uses: mbrobbel/rustfmt-check@b8caf241958773f7f6b0fba68879316da6be821d
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Apparently short SHAs can't be used anymore, so upgrade the action in the process.

[Differences](https://github.com/mbrobbel/rustfmt-check/compare/2d0978f...b8caf241958773f7f6b0fba68879316da6be821d?w=1)