### PR TITLE
ci: modernize (2025 edition)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,19 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust via mise
+        uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
-          override: true
-          profile: minimal
-          toolchain: stable
+          experimental: true
 
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - name: Run 'cargo check'
+        run: cargo check
 
   test:
     name: Test Suite
@@ -38,45 +34,36 @@ jobs:
         os: [macOS, windows]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust via mise
+        uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
-          override: true
-          profile: minimal
-          toolchain: stable
+          experimental: true
 
       - name: Run Tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: mise run test
 
   coverage:
     name: Test Suite (Linux, Code Coverage)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust via mise
+        uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
-          override: true
-          profile: minimal
-          toolchain: stable
+          experimental: true
 
       - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: '0.14.2'
-          args: '-- --test-threads 1'
+        run: mise run test:coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
           path: cobertura.xml
@@ -118,24 +105,16 @@ jobs:
           sudo dpkg --add-architecture i386
           sudo apt update
           sudo apt-get install --yes --no-install-recommends libssl-dev:i386
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - name: Install Rust via mise
+        uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
-          override: true
-          profile: minimal
-          target: ${{ matrix.target }}
-          toolchain: stable
-      - name: Install Cross 0.1.x
+          experimental: true
+      - name: Install Cross 0.2.x
         if: matrix.cross == true
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cross --version 0.1.16
-      - uses: actions-rs/cargo@v1
-        with:
-          use-cross: ${{ matrix.cross }}
-          command: build
-          args: --release --target=${{ matrix.target }}
+        run: cargo install cross --version 0.2.5
+      - name: Build with Cross
+        run: cross build --release --target ${{ matrix.target }}
         env:
           PKG_CONFIG_ALLOW_CROSS: 1
 
@@ -144,50 +123,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust via mise
+        uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
+          experimental: true
 
-      - name: rustfmt
-        uses: mbrobbel/rustfmt-check@b8caf241958773f7f6b0fba68879316da6be821d
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features -- -D warnings
+      - name: Run linters
+        run: mise run lint
 
   docs:
     name: Docs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Fetch all git branches
         run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust via mise
+        uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
+          experimental: true
 
       - name: Build docs
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
+        run: cargo doc
+
       - name: Publish to GitHub Pages
-        uses: docker://malept/gha-gh-pages:1.2.0
+        uses: malept/github-action-gh-pages@v1.4.0
         if: github.event_name == 'push'
         with:
           defaultBranch: main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Run Tests
         run: mise run test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   coverage:
     name: Test Suite (Linux, Code Coverage)
@@ -65,9 +67,13 @@ jobs:
       # Should speed up cargo-tarpaulin installation
       - name: Install cargo-binstall
         run: mise use cargo-binstall
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run cargo-tarpaulin
         run: mise run test:coverage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
@@ -147,6 +153,8 @@ jobs:
 
       - name: Run linters
         run: mise run lint
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   docs:
     name: Docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,10 @@ jobs:
         with:
           experimental: true
 
+      # Should speed up cargo-tarpaulin installation
+      - name: Install cargo-binstall
+        run: mise use cargo-binstall
+
       - name: Run cargo-tarpaulin
         run: mise run test:coverage
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,6 @@ jobs:
       - name: Install Rust via mise
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
-          cache: false
           experimental: true
           mise_toml: |
             [tools]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
           experimental: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run 'cargo check'
         run: cargo check
@@ -40,6 +42,8 @@ jobs:
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
           experimental: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Tests
         run: mise run test
@@ -55,6 +59,8 @@ jobs:
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
           experimental: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Should speed up cargo-tarpaulin installation
       - name: Install cargo-binstall
@@ -118,6 +124,8 @@ jobs:
             [tools]
             rust = "stable"
             "ubi:cross-rs/cross" = "0.1"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build with Cross
         run: cross build --release --target ${{ matrix.target }}
         env:
@@ -134,6 +142,8 @@ jobs:
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
           experimental: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run linters
         run: mise run lint
@@ -152,6 +162,8 @@ jobs:
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
           experimental: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build docs
         run: cargo doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,10 @@ jobs:
 
   coverage:
     name: Test Suite (Linux, Code Coverage)
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
           experimental: true
           mise_toml: |
             [tools]
-            rust = "stable"
+            rust = { version = "stable", profile = "minimal", targets = "${{ matrix.target }}" }
             "ubi:cross-rs/cross" = "0.1"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,9 @@ jobs:
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
           experimental: true
+          tool_versions: |
+            cargo-machete latest
+            taplo latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Archive code coverage results
         uses: actions/upload-artifact@v4
         with:
-          name: code-coverage-report
+          name: code-coverage-report-${{ matrix.os }}
           path: cobertura.xml
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,8 @@ jobs:
             "ubi:cross-rs/cross" = "0.1"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Ensure target is installed
+        run: rustup target add ${{ matrix.target }}
       - name: Build with Cross
         run: cross build --release --target ${{ matrix.target }}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
       - name: Install Rust via mise
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
+          cache: false
           experimental: true
           mise_toml: |
             [tools]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,9 +114,10 @@ jobs:
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
           experimental: true
-      - name: Install Cross 0.2.x
-        if: matrix.cross == true
-        run: cargo install cross --version 0.2.5
+          mise_toml: |
+            [tools]
+            rust = "stable"
+            "ubi:cross-rs/cross" = "0.1"
       - name: Build with Cross
         run: cross build --release --target ${{ matrix.target }}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,14 +126,13 @@ jobs:
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
           experimental: true
+          install_args: --force
           mise_toml: |
             [tools]
             rust = { version = "stable", profile = "minimal", targets = "${{ matrix.target }}" }
             "ubi:cross-rs/cross" = "0.1"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Ensure target is installed
-        run: rustup target add ${{ matrix.target }}
       - name: Build with Cross
         run: cross build --release --target ${{ matrix.target }}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,6 @@ jobs:
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
           experimental: true
-          install_args: --force
           mise_toml: |
             [tools]
             rust = { version = "stable", profile = "minimal", targets = "${{ matrix.target }}" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,11 @@ jobs:
 
   test:
     name: Test Suite
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS, windows]
+        # macos-13 is Intel macOS, macos-latest is Apple Silicon macOS
+        os: [macos-13, macos-latest, windows-latest]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/daily-lints.yml
+++ b/.github/workflows/daily-lints.yml
@@ -9,23 +9,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust via mise
+        uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
+          experimental: true
+          tool_versions: |
+            cargo-machete latest
+            taplo latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: rustfmt
-        uses: mbrobbel/rustfmt-check@b8caf241958773f7f6b0fba68879316da6be821d
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features -- -D warnings
+      - name: Run linters
+        run: mise run lint
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/mise.toml
+++ b/mise.toml
@@ -66,4 +66,4 @@ run = "cargo nextest run --no-fail-fast"
 [tasks."test:coverage"]
 tools.cargo-tarpaulin = "latest"
 description = "Run test coverage via tarpaulin"
-run = "cargo tarpaulin"
+run = "cargo tarpaulin --out xml"

--- a/mise.toml
+++ b/mise.toml
@@ -2,11 +2,9 @@
 cargo-machete = "ubi:bnjbvr/cargo-machete"
 cargo-nextest = "aqua:nextest-rs/nextest/cargo-nextest"
 cargo-tarpaulin = "cargo:cargo-tarpaulin"
-cross = "ubi:cross-rs/cross"
 
 [tools]
 actionlint = "latest"
-cross = "0.1"
 rust = "stable"
 
 [tasks."docs:build"]

--- a/mise.toml
+++ b/mise.toml
@@ -63,7 +63,7 @@ run = "taplo format --check --diff"
 [tasks.test]
 tools.cargo-nextest = "latest"
 description = "Run Rust tests"
-run = "cargo nextest run"
+run = "cargo nextest run --no-fail-fast"
 
 [tasks."test:coverage"]
 tools.cargo-tarpaulin = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@ cross = "ubi:cross-rs/cross"
 
 [tools]
 actionlint = "latest"
-cross = "latest"
+cross = "0.1"
 rust = "stable"
 
 [tasks."docs:build"]

--- a/mise.toml
+++ b/mise.toml
@@ -1,8 +1,13 @@
 [alias]
 cargo-machete = "ubi:bnjbvr/cargo-machete"
+cargo-nextest = "aqua:nextest-rs/nextest/cargo-nextest"
+cargo-tarpaulin = "cargo:cargo-tarpaulin"
+cross = "ubi:cross-rs/cross"
 
 [tools]
 actionlint = "latest"
+cross = "latest"
+rust = "stable"
 
 [tasks."docs:build"]
 description = "Build Rust docs"
@@ -54,3 +59,13 @@ run = "taplo lint"
 tools.taplo = "latest"
 description = "Checks if TOML files are formatted correctly"
 run = "taplo format --check --diff"
+
+[tasks.test]
+tools.cargo-nextest = "latest"
+description = "Run Rust tests"
+run = "cargo nextest run"
+
+[tasks."test:coverage"]
+tools.cargo-tarpaulin = "latest"
+description = "Run test coverage via tarpaulin"
+run = "cargo tarpaulin"


### PR DESCRIPTION
CI is super out of date, fix that.

* Use `mise` and its action to install Rust, linters, etc.
* Use `mise` to run tasks in CI
* Test on Linux/arm64 and macOS/amd64
* Don't upgrade to cross >= 0.2 because we still depend on system openssl