### PR TITLE
refactor: replace crypto-hash with rustcrypto crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
 
   test:
     name: Test Suite
+    needs: [check]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -53,6 +54,7 @@ jobs:
 
   coverage:
     name: Test Suite (Linux, Code Coverage)
+    needs: [check]
     strategy:
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm]
@@ -91,6 +93,7 @@ jobs:
   build:
     name: Build Only
     runs-on: ${{ matrix.os }}-latest
+    needs: [check]
     strategy:
       matrix:
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,35 +96,21 @@ jobs:
         include:
           - os: ubuntu
             target: aarch64-linux-android
-            cross: true
           - os: ubuntu
             target: arm-linux-androideabi
-            cross: true
           - os: ubuntu
             target: armv7-unknown-linux-gnueabihf
-            cross: true
           - os: ubuntu
             target: powerpc64-unknown-linux-gnu
-            cross: true
           - os: ubuntu
             target: x86_64-unknown-linux-musl
-            cross: true
           - os: ubuntu
             target: i686-unknown-linux-gnu
-            cross: false
           - os: macOS
             target: aarch64-apple-ios
-            cross: false
           - os: macOS
             target: x86_64-apple-ios
-            cross: false
     steps:
-      - name: Install OpenSSL (32-bit)
-        if: matrix.target == 'i686-unknown-linux-gnu'
-        run: |
-          sudo dpkg --add-architecture i386
-          sudo apt update
-          sudo apt-get install --yes --no-install-recommends libssl-dev:i386
       - uses: actions/checkout@v4
       - name: Install Rust via mise
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
@@ -133,7 +119,7 @@ jobs:
           mise_toml: |
             [tools]
             rust = { version = "stable", profile = "minimal", targets = "${{ matrix.target }}" }
-            "ubi:cross-rs/cross" = "0.1"
+            "ubi:cross-rs/cross" = "0.2"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Ensure target is installed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,7 @@ tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
 
 [lints.clippy]
 pedantic = "allow"
+
+[package.metadata.cargo-machete]
+# This is because the crate name does not match the library name (md5)
+ignored = ["md-5"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["edition2024"]
 
 [package]
 name = "guardhaus"
-version = "0.0.16"
+version = "0.0.17"
 authors = ["Mark Lee"]
 description = "An HTTP authentication/authorization library."
 documentation = "https://malept.github.io/guardhaus/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,19 +13,22 @@ license = "MIT"
 edition = "2024"
 
 [dependencies]
-crypto-hash = "0.3"
+base16ct = { version = "0.2.0", features = ["alloc"] }
+digest = "0.10.7"
 headers = "0.4.0"
-hex = "0.4.2"
 http = "1.2.0"
 httparse = "1.10.0"
 language-tags = "0.3.2"
+md-5 = "0.10.6"
 percent-encoding = "2.1.0"
+sha2 = "0.10.8"
 thiserror = "2.0.11"
 unicase = "2.0"
 
 [dev-dependencies]
 anyhow = "1.0.96"
 axum = "0.8.1"
+axum-extra = "0.10.0"
 getopts = "0.2"
 rpassword = "7.3.1"
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }

--- a/src/digest/mod.rs
+++ b/src/digest/mod.rs
@@ -23,8 +23,8 @@
 use crate::parsing::fromheaders::{Charset, ExtendedValue};
 use crate::parsing::{DigestParameters, parse_parameters, unraveled_map_value};
 use crate::types::{HashAlgorithm, NonceCount, Qop};
-use headers::Error;
 use headers::authorization::Credentials;
+use headers::{Authorization, Error};
 use http::{HeaderValue, Method};
 use std::collections::HashMap;
 use std::fmt;
@@ -231,12 +231,18 @@ impl FromStr for Digest {
 }
 
 impl Digest {
+    /// Returns a copy wrapped with an Authorization header.
+    pub fn to_header(&self) -> Authorization<Digest> {
+        Authorization(self.clone())
+    }
+
     /// Generates a userhash, as defined in
     /// [RFC 7616, section 3.4.4](https://tools.ietf.org/html/rfc7616#section-3.4.4).
     pub fn userhash(algorithm: &HashAlgorithm, username: Vec<u8>, realm: String) -> String {
-        let mut to_hash = username;
+        let mut to_hash = username.clone();
         to_hash.push(b':');
         to_hash.append(&mut realm.into_bytes());
+        println!("value: {:?}", std::str::from_utf8(&to_hash));
         algorithm.hex_digest(to_hash.as_slice())
     }
 

--- a/src/digest/test.rs
+++ b/src/digest/test.rs
@@ -335,8 +335,11 @@ fn test_fmt_scheme_with_extended_username() {
 }
 
 #[test]
-fn test_userhash() {
-    let expected = "488869477bf257147b804c45308cd62ac4e25eb717b12b298c79e62dcea254ec".to_owned();
+fn userhash_with_extended_value_username_and_sha256512() {
+    // From: RFC 7616, Section 3.9.2
+    // https://datatracker.ietf.org/doc/html/rfc7616#section-3.9.2
+    // Expected hash from: https://www.rfc-editor.org/errata/eid4897
+    let expected = "793263caabb707a56211940d90411ea4a575adeccb7e360aeb624ed06ece9b0b".to_owned();
     if let Username::Encoded(username) = rfc7616_username() {
         let actual = Digest::userhash(
             &HashAlgorithm::Sha512256,
@@ -351,7 +354,7 @@ fn test_userhash() {
 
 #[test]
 fn test_validate_userhash() {
-    let userhash = "488869477bf257147b804c45308cd62ac4e25eb717b12b298c79e62dcea254ec".to_owned();
+    let userhash = "793263caabb707a56211940d90411ea4a575adeccb7e360aeb624ed06ece9b0b".to_owned();
     let digest = rfc7616_sha512_256_header(userhash, true);
 
     assert!(digest.validate_userhash(rfc7616_username()));
@@ -584,7 +587,9 @@ fn test_validate_using_password() {
 
 #[test]
 fn test_validate_using_encoded_username_and_password() {
-    // From RFC 7616
+    // From: RFC 7616, Section 3.9.2
+    // https://datatracker.ietf.org/doc/html/rfc7616#section-3.9.2
+    // Adjusted from errata: https://www.rfc-editor.org/errata/eid4897
     let password = "Secret, or not?".to_owned();
     let header = parse_digest_header(
         "Digest username*=UTF-8''J%C3%A4s%C3%B8n%20Doe, \
@@ -594,7 +599,7 @@ fn test_validate_using_encoded_username_and_password() {
                                       nc=00000001, \
                                       cnonce=\"NTg6RKcb9boFIAS3KrFK9BGeh+iDa/sm6jUMp2wds69v\", \
                                       qop=auth, \
-                                      response=\"ae66e67d6b427bd3f120414a82e4acff38e8ecd9101d6c861229025f607a79dd\", \
+                                      response=\"3798d4131c277846293534c3edc11bd8a5e4cdcbff78b05db9d95eeb1cec68a5\", \
                                       opaque=\"HRPCssKJSGjCrkzDg8OhwpzCiGPChXYjwrI2QmXDnsOS\", \
                                       userhash=false",
     );
@@ -603,17 +608,19 @@ fn test_validate_using_encoded_username_and_password() {
 
 #[test]
 fn test_validate_using_userhash_and_password() {
-    // From RFC 7616
+    // From: RFC 7616, Section 3.9.2
+    // https://datatracker.ietf.org/doc/html/rfc7616#section-3.9.2
+    // Adjusted from errata: https://www.rfc-editor.org/errata/eid4897
     let password = "Secret, or not?".to_owned();
     let header = parse_digest_header(
-        "Digest username=\"488869477bf257147b804c45308cd62ac4e25eb717b12b298c79e62dcea254ec\", \
+        "Digest username=\"793263caabb707a56211940d90411ea4a575adeccb7e360aeb624ed06ece9b0b\", \
                                       realm=\"api@example.org\", uri=\"/doe.json\", \
                                       algorithm=SHA-512-256, \
                                       nonce=\"5TsQWLVdgBdmrQ0XsxbDODV+57QdFR34I9HAbC/RVvkK\", \
                                       nc=00000001, \
                                       cnonce=\"NTg6RKcb9boFIAS3KrFK9BGeh+iDa/sm6jUMp2wds69v\", \
                                       qop=auth, \
-                                      response=\"ae66e67d6b427bd3f120414a82e4acff38e8ecd9101d6c861229025f607a79dd\", \
+                                      response=\"3798d4131c277846293534c3edc11bd8a5e4cdcbff78b05db9d95eeb1cec68a5\", \
                                       opaque=\"HRPCssKJSGjCrkzDg8OhwpzCiGPChXYjwrI2QmXDnsOS\", \
                                       charset=UTF-8, userhash=true",
     );

--- a/src/digest/test_helper.rs
+++ b/src/digest/test_helper.rs
@@ -134,12 +134,15 @@ pub fn rfc2617_digest_header(algorithm: HashAlgorithm) -> Digest {
     }
 }
 
+// See: RFC 7616, Section 3.9.2
+// https://datatracker.ietf.org/doc/html/rfc7616#section-3.9.2
 pub fn rfc7616_username() -> Username {
     let result: Result<ExtendedValue, headers::Error> = "UTF-8''J%C3%A4s%C3%B8n%20Doe".parse();
     Username::Encoded(result.expect("Could not parse extended value"))
 }
 
 // See: RFC 7616, Section 3.9.1
+// https://datatracker.ietf.org/doc/html/rfc7616#section-3.9.1
 pub fn rfc7616_digest_header(algorithm: HashAlgorithm, response: &str) -> Digest {
     Digest {
         username: rfc2069_username(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -21,8 +21,7 @@
 //! Common authentication types.
 
 use crate::parsing::unraveled_map_value;
-use crypto_hash;
-use hex::FromHex;
+use digest::Digest;
 use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
@@ -90,25 +89,18 @@ impl fmt::Display for HashAlgorithm {
 }
 
 impl HashAlgorithm {
-    fn to_algorithm(&self) -> crypto_hash::Algorithm {
-        match *self {
-            HashAlgorithm::Md5 | HashAlgorithm::Md5Session => crypto_hash::Algorithm::MD5,
-            HashAlgorithm::Sha256 | HashAlgorithm::Sha256Session => crypto_hash::Algorithm::SHA256,
-            HashAlgorithm::Sha512256 | HashAlgorithm::Sha512256Session => {
-                crypto_hash::Algorithm::SHA512
-            }
-        }
-    }
-
     /// Generate a hexadecimal representation of the output of a cryptographic hash function, given
     /// `data` and the algorithm.
     pub fn hex_digest(&self, data: &[u8]) -> String {
-        let mut digest = crypto_hash::hex_digest(self.to_algorithm(), data);
-        if *self == HashAlgorithm::Sha512256 || *self == HashAlgorithm::Sha256Session {
-            digest.truncate(64);
+        match self {
+            Self::Md5 | Self::Md5Session => base16ct::lower::encode_string(&md5::Md5::digest(data)),
+            Self::Sha256 | Self::Sha256Session => {
+                base16ct::lower::encode_string(&sha2::Sha256::digest(data))
+            }
+            Self::Sha512256 | Self::Sha512256Session => {
+                base16ct::lower::encode_string(&sha2::Sha512_256::digest(data))
+            }
         }
-
-        digest
     }
 }
 
@@ -119,7 +111,7 @@ pub struct NonceCount(pub u32);
 impl FromStr for NonceCount {
     type Err = AuthorizationError;
     fn from_str(s: &str) -> Result<NonceCount, AuthorizationError> {
-        match Vec::from_hex(s) {
+        match base16ct::mixed::decode_vec(s) {
             Ok(bytes) => {
                 let mut count: u32 = 0;
                 count |= (bytes[0] as u32) << 24;

--- a/src/types.rs
+++ b/src/types.rs
@@ -194,3 +194,36 @@ impl Qop {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::HashAlgorithm;
+
+    #[test]
+    fn hash_algorithm_hex_digest_md5() {
+        // From: https://en.wikipedia.org/wiki/MD5#MD5_hashes
+        let data = "The quick brown fox jumps over the lazy dog";
+        assert_eq!(
+            HashAlgorithm::Md5.hex_digest(data.as_bytes()),
+            String::from("9e107d9d372bb6826bd81d3542a419d6")
+        )
+    }
+
+    #[test]
+    fn hash_algorithm_hex_digest_sha256() {
+        // From: https://en.wikipedia.org/wiki/SHA-2#Test_vectors
+        assert_eq!(
+            HashAlgorithm::Sha256.hex_digest("".as_bytes()),
+            String::from("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+        )
+    }
+
+    #[test]
+    fn hash_algorithm_hex_digest_sha512256() {
+        // From: https://en.wikipedia.org/wiki/SHA-2#Test_vectors
+        assert_eq!(
+            HashAlgorithm::Sha512256.hex_digest("".as_bytes()),
+            String::from("c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a")
+        )
+    }
+}


### PR DESCRIPTION
* Incorporate [errata from RFC 7616](https://www.rfc-editor.org/errata_search.php?rfc=7616).
* Update CI to use latest `cross` now that the OpenSSL dependency has been removed