### PR TITLE
ci: upload test results/coverage to Codecov

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.ci.junit]
+path = "junit.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Archive code coverage results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Tests
-        run: mise run test
+        run: mise run test:ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706 #v1.1.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/nextest/ci/junit.xml
 
   coverage:
     name: Test Suite (Linux, Code Coverage)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/nextest/ci/junit.xml
+          flags: ${{ matrix.os }}
 
   coverage:
     name: Test Suite (Linux, Code Coverage)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Guardhaus
 
-[![CI Status](https://github.com/malept/guardhaus/workflows/CI/badge.svg?branch=main)](https://github.com/malept/guardhaus/actions?query=workflow%3ACI)
+[![CI](https://github.com/malept/guardhaus/actions/workflows/ci.yml/badge.svg)](https://github.com/malept/guardhaus/actions/workflows/ci.yml)
 [![Coverage Status](https://codecov.io/gh/malept/guardhaus/graph/badge.svg?token=dtyMhcbE2w)](https://codecov.io/gh/malept/guardhaus)
 
 Guardhaus is an HTTP authentication/authorization library, written in Rust.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Guardhaus
 
 [![CI Status](https://github.com/malept/guardhaus/workflows/CI/badge.svg?branch=main)](https://github.com/malept/guardhaus/actions?query=workflow%3ACI)
-[![Coverage Status](https://coveralls.io/repos/malept/guardhaus/badge.svg?branch=main&service=github)](https://coveralls.io/github/malept/guardhaus?branch=main)
+[![Coverage Status](https://codecov.io/gh/malept/guardhaus/graph/badge.svg?token=dtyMhcbE2w)](https://codecov.io/gh/malept/guardhaus)
 
 Guardhaus is an HTTP authentication/authorization library, written in Rust.
 

--- a/mise.toml
+++ b/mise.toml
@@ -63,6 +63,11 @@ tools.cargo-nextest = "latest"
 description = "Run Rust tests"
 run = "cargo nextest run --no-fail-fast"
 
+[tasks."test:ci"]
+tools.cargo-nextest = "latest"
+description = "Run Rust tests via nextest with the ci profile"
+run = "cargo nextest run --no-fail-fast --profile ci"
+
 [tasks."test:coverage"]
 tools.cargo-tarpaulin = "latest"
 description = "Run test coverage via tarpaulin"


### PR DESCRIPTION
`cargo nextest` supports JUnit files, so generate it and upload to Codecov.