### PR TITLE
refactor(ci): replace tarpaulin with cargo-llvm-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Tests
+        if: matrix.os == 'windows-11-arm'
+        run: mise run test:ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Tests (Code coverage)
+        if: matrix.os != 'windows-11-arm' # cargo-llvm-cov doesn't have Windows/Arm support yet
         run: mise run test:coverage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -66,11 +73,13 @@ jobs:
           flags: ${{ matrix.os }}
 
       - name: Upload coverage to Codecov
+        if: matrix.os != 'windows-11-arm' # cargo-llvm-cov doesn't have Windows/Arm support yet
         uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Archive code coverage results
+        if: matrix.os != 'windows-11-arm' # cargo-llvm-cov doesn't have Windows/Arm support yet
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report-${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macos-13 is Intel macOS, macos-latest is Apple Silicon macOS
-        os: [macos-13, macos-latest, windows-latest, windows-11-arm]
+        os:
+          - macos-13 # Intel
+          - macos-latest # Apple Silicon
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+          - windows-latest
+          - windows-11-arm
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -60,35 +65,6 @@ jobs:
           files: target/nextest/ci/junit.xml
           flags: ${{ matrix.os }}
 
-  coverage:
-    name: Test Suite (Linux, Code Coverage)
-    needs: [check]
-    strategy:
-      matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Install Rust via mise
-        uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
-        with:
-          experimental: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Should speed up cargo-tarpaulin installation
-      - name: Install cargo-binstall
-        run: mise use cargo-binstall
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run cargo-tarpaulin
-        run: mise run test:coverage
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
@@ -98,7 +74,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report-${{ matrix.os }}
-          path: cobertura.xml
+          path: lcov.info
 
   build:
     name: Build Only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Tests
-        run: mise run test:ci
+        run: mise run test:coverage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.bk
 Cargo.lock
 target
+lcov.info

--- a/mise.toml
+++ b/mise.toml
@@ -64,6 +64,7 @@ description = "Run Rust tests"
 run = "cargo nextest run --no-fail-fast"
 
 [tasks."test:ci"]
+tools.cargo-nextest = "latest"
 description = "Run Rust tests via nextest with the ci profile"
 run = "cargo nextest run --no-fail-fast --profile ci"
 

--- a/mise.toml
+++ b/mise.toml
@@ -63,16 +63,12 @@ tools.cargo-nextest = "latest"
 description = "Run Rust tests"
 run = "cargo nextest run --no-fail-fast"
 
-[tasks."test:ci"]
-tools.cargo-nextest = "latest"
-description = "Run Rust tests via nextest with the ci profile"
-run = "cargo nextest run --no-fail-fast --profile ci"
-
 [tasks."test:coverage"]
 tools.cargo-llvm-cov = "latest"
+tools.cargo-nextest = "latest"
 description = "Run test coverage via cargo-llvm-cov"
 run = [
-  "cargo llvm-cov --no-report nextest",
+  "cargo llvm-cov --no-report nextest --no-fail-fast --profile ci",
   # No doctests yet because it's nightly-only
   "cargo llvm-cov report --lcov --output-path lcov.info",
 ]

--- a/mise.toml
+++ b/mise.toml
@@ -1,11 +1,11 @@
 [alias]
+cargo-llvm-cov = "ubi:taiki-e/cargo-llvm-cov"
 cargo-machete = "ubi:bnjbvr/cargo-machete"
 cargo-nextest = "aqua:nextest-rs/nextest/cargo-nextest"
-cargo-tarpaulin = "cargo:cargo-tarpaulin"
 
 [tools]
 actionlint = "latest"
-rust = "stable"
+rust = { version = "stable", components = "llvm-tools-preview" }
 
 [tasks."docs:build"]
 description = "Build Rust docs"
@@ -69,6 +69,10 @@ description = "Run Rust tests via nextest with the ci profile"
 run = "cargo nextest run --no-fail-fast --profile ci"
 
 [tasks."test:coverage"]
-tools.cargo-tarpaulin = "latest"
-description = "Run test coverage via tarpaulin"
-run = "cargo tarpaulin --out xml"
+tools.cargo-llvm-cov = "latest"
+description = "Run test coverage via cargo-llvm-cov"
+run = [
+  "cargo llvm-cov --no-report nextest",
+  # No doctests yet because it's nightly-only
+  "cargo llvm-cov report --lcov --output-path lcov.info",
+]

--- a/mise.toml
+++ b/mise.toml
@@ -63,6 +63,10 @@ tools.cargo-nextest = "latest"
 description = "Run Rust tests"
 run = "cargo nextest run --no-fail-fast"
 
+[tasks."test:ci"]
+description = "Run Rust tests via nextest with the ci profile"
+run = "cargo nextest run --no-fail-fast --profile ci"
+
 [tasks."test:coverage"]
 tools.cargo-llvm-cov = "latest"
 tools.cargo-nextest = "latest"


### PR DESCRIPTION
`tarpaulin` doesn't currently work with `nextest`, unfortunately.

`cargo-llvm-cov` doesn't currently provide a binary for Windows on Arm, so run the testsuite with just `nextest` in that case. It was only running code coverage on Linux before, so it's not really a big loss.